### PR TITLE
test: agregar pruebas unitarias para la UH01

### DIFF
--- a/src/test/java/com/interride/service/PasajeroServiceUnitTest.java
+++ b/src/test/java/com/interride/service/PasajeroServiceUnitTest.java
@@ -1,26 +1,200 @@
 package com.interride.service;
 
+import com.interride.dto.request.PasajeroRegistrationRequest;
+import com.interride.dto.response.PasajeroProfileResponse;
 import com.interride.mapper.PasajeroMapper;
+import com.interride.model.entity.Pasajero;
 import com.interride.repository.PasajeroRepository;
+import com.interride.service.Impl.PasajeroServiceImpl;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
-public class PasajeroServiceUnitTest {
-    @Mock private PasajeroRepository pasajeroRepository;
-    @Mock private PasajeroMapper mapper;
-    @Mock private PasswordEncoder encoder;
-    @Mock private EmailService emailService;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 
+/**
+ * Tests exhaustivos para HU‑01 (Registro de pasajero).
+ */
+@ExtendWith(MockitoExtension.class)
+class PasajeroServiceUnitTest {
+
+    /* ===== Dependencias mockeadas ===== */
+    @Mock private PasajeroRepository pasajeroRepository;
+    @Mock private PasswordEncoder    encoder;
+    @Mock private EmailService       emailService;
+    @Mock private PasajeroMapper     pasajeroMapper;
+
+    /* ===== SUT ===== */
     @InjectMocks
-    private PasajeroService pasajeroService;
+    private PasajeroServiceImpl pasajeroService;
+
+    /* ===== Captor ===== */
+    @Captor
+    private ArgumentCaptor<Pasajero> pasajeroCaptor;
+
+    /* ===== Fixture común ===== */
+    private PasajeroRegistrationRequest request;
 
     @BeforeEach
     void setUp() {
-        MockitoAnnotations.openMocks(this);
+        request = new PasajeroRegistrationRequest();
+        request.setNombre("Juan");
+        request.setApellidos("Pérez");
+        request.setCorreo("juan@mail.com");
+        request.setTelefono("987654321");
+        request.setPassword("plainPass");
+        request.setUsername("juanUser");
     }
 
-    //TESTS
+    /* ----------------------------------------------------------------
+     *                       CASOS EXITOSOS
+     * --------------------------------------------------------------- */
+    @Nested @DisplayName("Escenarios exitosos")
+    class Successful {
+
+        @Test
+        @DisplayName("CP01 – Registro exitoso con verificaciones completas")
+        void shouldRegisterPassengerSuccessfully() {
+            /* ---- Arrange ---- */
+            when(pasajeroRepository.existsByCorreo(request.getCorreo())).thenReturn(false);
+            when(pasajeroRepository.existsByTelefono(request.getTelefono())).thenReturn(false);
+
+            Pasajero mappedEntity = Pasajero.builder()
+                    .nombre   (request.getNombre())
+                    .apellidos(request.getApellidos())
+                    .correo   (request.getCorreo())
+                    .telefono (request.getTelefono())
+                    .username (request.getUsername())
+                    .build();
+            when(pasajeroMapper.toEntity(request)).thenReturn(mappedEntity);
+
+            when(encoder.encode(request.getPassword())).thenReturn("encodedPass");
+
+            Pasajero savedEntity = Pasajero.builder()
+                    .id       (1)
+                    .nombre   (request.getNombre())
+                    .apellidos(request.getApellidos())
+                    .correo   (request.getCorreo())
+                    .telefono (request.getTelefono())
+                    .username (request.getUsername())
+                    .password ("encodedPass")
+                    .build();
+            when(pasajeroRepository.save(any(Pasajero.class))).thenReturn(savedEntity);
+
+            PasajeroProfileResponse expectedResponse = PasajeroProfileResponse.builder()
+                    .id       (1)
+                    .nombre   (request.getNombre())
+                    .apellidos(request.getApellidos())
+                    .correo   (request.getCorreo())
+                    .telefono (request.getTelefono())
+                    .username (request.getUsername())
+                    .build();
+            when(pasajeroMapper.toProfileDTO(savedEntity)).thenReturn(expectedResponse);
+
+            /* ---- Act ---- */
+            PasajeroProfileResponse actual = pasajeroService.register(request);
+
+            /* ---- Assert salida ---- */
+            assertThat(actual).isEqualTo(expectedResponse);
+
+            /* ---- Assert interacciones ---- */
+            verify(pasajeroRepository).save(pasajeroCaptor.capture());
+            Pasajero persisted = pasajeroCaptor.getValue();
+            assertThat(persisted.getPassword()).isEqualTo("encodedPass");
+            assertThat(persisted.getCorreo())
+                    .isEqualTo(request.getCorreo());
+
+            verify(encoder).encode(request.getPassword());
+            verify(emailService)
+                    .sendRegistrationConfirmation(eq(request.getCorreo()), anyString(), anyString());
+        }
+    }
+
+    /* ----------------------------------------------------------------
+     *              CASOS FALLIDOS POR DUPLICIDAD
+     * --------------------------------------------------------------- */
+    @Nested @DisplayName("Escenarios fallidos por duplicidad")
+    class Failures {
+
+        @Test
+        @DisplayName("CP02 – Correo duplicado provoca excepción")
+        void shouldFailWhenEmailExists() {
+            when(pasajeroRepository.existsByCorreo(request.getCorreo())).thenReturn(true);
+
+            assertThatThrownBy(() -> pasajeroService.register(request))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("correo ya está registrado");
+
+            verify(pasajeroRepository, never()).save(any());
+            verify(emailService,     never()).sendRegistrationConfirmation(anyString(), anyString(), anyString());
+        }
+
+        @Test
+        @DisplayName("CP03 – Teléfono duplicado provoca excepción")
+        void shouldFailWhenPhoneExists() {
+            when(pasajeroRepository.existsByCorreo(request.getCorreo())).thenReturn(false);
+            when(pasajeroRepository.existsByTelefono(request.getTelefono())).thenReturn(true);
+
+            assertThatThrownBy(() -> pasajeroService.register(request))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("teléfono ya está registrado");
+
+            verify(pasajeroRepository, never()).save(any());
+            verify(emailService,     never()).sendRegistrationConfirmation(anyString(), anyString(), anyString());
+        }
+    }
+
+    /* ----------------------------------------------------------------
+     *        CASO FALLIDO POR ERROR EN EL SERVICIO DE EMAIL
+     * --------------------------------------------------------------- */
+    @Nested @DisplayName("Escenario de falla en servicio de correo")
+    class EmailFailure {
+
+        @Test
+        @DisplayName("CP04 – Error en EmailService se propaga")
+        void shouldPropagateWhenEmailServiceFails() {
+            when(pasajeroRepository.existsByCorreo(request.getCorreo())).thenReturn(false);
+            when(pasajeroRepository.existsByTelefono(request.getTelefono())).thenReturn(false);
+
+            Pasajero mapped = Pasajero.builder()
+                    .nombre  (request.getNombre())
+                    .correo  (request.getCorreo())
+                    .telefono(request.getTelefono())
+                    .build();
+            when(pasajeroMapper.toEntity(request)).thenReturn(mapped);
+            when(encoder.encode(request.getPassword())).thenReturn("encodedPass");
+
+            Pasajero saved = Pasajero.builder()
+                    .id       (2)
+                    .nombre   (request.getNombre())
+                    .apellidos(request.getApellidos())
+                    .correo   (request.getCorreo())
+                    .telefono (request.getTelefono())
+                    .username (request.getUsername())
+                    .password ("encodedPass")
+                    .build();
+            when(pasajeroRepository.save(any(Pasajero.class))).thenReturn(saved);
+
+            doThrow(new RuntimeException("SMTP down"))
+                    .when(emailService).sendRegistrationConfirmation(anyString(), anyString(), anyString());
+
+            assertThatThrownBy(() -> pasajeroService.register(request))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasMessageContaining("SMTP down");
+
+            verify(pasajeroRepository).save(any(Pasajero.class));
+            verify(emailService)
+                    .sendRegistrationConfirmation(eq(request.getCorreo()), anyString(), anyString());
+        }
+    }
 }

--- a/src/test/java/com/interride/service/ViajeServiceUnitTest.java
+++ b/src/test/java/com/interride/service/ViajeServiceUnitTest.java
@@ -370,6 +370,7 @@ public class ViajeServiceUnitTest {
         assertThrows(ResourceNotFoundException.class, () -> {
             viajeService.getViajesByPasajeroId(pasajeroId);
         });
+        }
 
     @DisplayName("UH11 - CP01 - Aceptar viaje con exito")
     void aceptarViaje_success_returnsAccepted() {


### PR DESCRIPTION
• Se añaden 4 casos de prueba (CP01–CP04) cubriendo los escenarios
  de la HU01 (Registro de pasajero).
• Cobertura de servicio PasajeroServiceImpl > 95 % líneas / 100 % ramas.
• Incluye mocks de repositorio, mapper y EmailService.

![image](https://github.com/user-attachments/assets/7f9787fa-598e-497a-869e-839028d1b175)
